### PR TITLE
Bug with external links fixed

### DIFF
--- a/script.js
+++ b/script.js
@@ -155,7 +155,7 @@
 						window.open('http://scmplayer.net/#skin='+tar.href,'_blank');
 						window.focus();
 						e.preventDefault();
-					}else if(filter(tar.href).indexOf(filter(location.host))==-1 ){
+					}else if(filter(tar.href).indexOf(filter(location.host))!=0 ){
 						if(tar.href.match(/^http(s)?/)){
 							//external links
 							window.open(tar.href,'_blank');


### PR DESCRIPTION
When the own domain (location.host) is in an external link, then the
handling of the link didn't work properly (it was considered as an
internal link).
Example:
my website: http://example.com
External link: http://www.facebook.com/example.com
