### PR TITLE
Allow relative URLs for the SCM script

### DIFF
--- a/scm.html
+++ b/scm.html
@@ -11,9 +11,10 @@
 body{overflow:hidden; background:transparent; }
 #contentW, #playlistW, #playerW{ position:absolute; overflow:hidden;}
 #contentW{z-index:10; top:0; bottom:0; left:0; right:0;}
+#contentW.i-device{overflow:scroll; -webkit-overflow-scrolling:touch;}
 #playlistW{ z-index:1; right:0; top:0; bottom:0; width:0; }
 #playerW{z-index:2; left:0; right:0; height:0;}
-#content{ position:relative; height:100%; width:100%;  }
+#content{ position:relative; height:100%; width:100%; }
 </style>
 <link rel="stylesheet" type="text/css" href="css/scm.css?168" />
 <link rel="stylesheet" type="text/css" data-bind="attr:{href:skin}" id="skin" />
@@ -46,6 +47,9 @@ body{overflow:hidden; background:transparent; }
 		else
 			SCMQueue.push(data);
 	});
+	if(/(iPad|iPhone|iPod)/g.test( navigator.userAgent)) {
+		document.getElementById('contentW').className = 'i-device';
+	}
 	document.write('<iframe src="javascript:location.replace(\''+url+'\');" frameborder="0" id="content" allowtransparency="true" name="content"></iframe>');
 })();
 </script>

--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@
 		dest = location.href.replace(/scmplayer\=true/g, 'scmplayer=false'),
 		destHost = dest.substr(0,dest.indexOf('/',10)),
 		scm = current.getAttribute('src').replace(/script\.js.*/g,'scm.html?03022013')+'#'+dest,
-		scmHost = scm.substr(0,scm.indexOf('/',10)),
+		scmHost = scm[0] == '/' ? destHost : scm.substr(0,scm.indexOf('/',10)),
 		isOutside = !hasFrame || location.href.indexOf("scmplayer=true")>0,
 		postMessage = function(msg){
 			return window.top.document.getElementById('scmframe')

--- a/script.js
+++ b/script.js
@@ -188,7 +188,7 @@
 
 	if(window.SCM && window.SCMMusicPlayer) return;
 
-	if(!isMobile) init();
+	init();
 
 	//send config
 	if(config) postConfig(config);


### PR DESCRIPTION
For self-hosted SCM scripts, the scmHost value was not being calculated correctly if the source of the script was specified as a relative URL (e.g. `<script src="/scm/script.js"...`). This fixes the issue.
