### PR TITLE
always treat target='_blank' links as external

### DIFF
--- a/script.js
+++ b/script.js
@@ -131,7 +131,8 @@
 				};
 			addEvent(document.body,'click',function(e){
 				var tar = e.target;
-				while(!tar.tagName.match(/^(a|area)$/i) && tar!=document.body) 
+				var ext = (tar.target == '_blank');
+				while(!tar.tagName.match(/^(a|area)$/i) && tar!=document.body)
 					tar = tar.parentNode;
 				if(tar.tagName.match(/^(a|area)$/i) && 
 					!tar.href.match(/.(jpg|png)$/i) && //ignore picture link
@@ -155,7 +156,7 @@
 						window.open('http://scmplayer.net/#skin='+tar.href,'_blank');
 						window.focus();
 						e.preventDefault();
-					}else if(filter(tar.href).indexOf(filter(location.host))==-1 ){
+					}else if(ext || filter(tar.href).indexOf(filter(location.host))==-1 ){
 						if(tar.href.match(/^http(s)?/)){
 							//external links
 							window.open(tar.href,'_blank');


### PR DESCRIPTION
I've been having trouble using scmplayer with subdomains (e.g., on http://podpodpodcast.com/, there is a link to http://feed.podpodpodcast.com/podpodpodcast, which scmplayer's link detection assumes should open within the iframe instead of externally, but then the URL replacement doesn't handle the subdomain properly and it goes to http://podpodpodcast.com/feed./podpodpodcast, which is a nonsense URL).

So I thought of this workaround: if the HTML specifies that a link should open in a new tab, then I think it would make sense for the scmplayer to comply with that and open in a new tab. It doesn't directly solve the problem of subdomain links getting mangled, but it would mean that that mangling could be easily avoided by telling the browser to open it in a new tab.

Hope this is helpful!
