### PR TITLE
Double-encode single quotes in URLs

### DIFF
--- a/scm.html
+++ b/scm.html
@@ -46,6 +46,7 @@ body{overflow:hidden; background:transparent; }
 		else
 			SCMQueue.push(data);
 	});
+	url = url.replace(/\%27/g, '%2527');
 	document.write('<iframe src="javascript:location.replace(\''+url+'\');" frameborder="0" id="content" allowtransparency="true" name="content"></iframe>');
 })();
 </script>

--- a/scm.html
+++ b/scm.html
@@ -46,7 +46,7 @@ body{overflow:hidden; background:transparent; }
 		else
 			SCMQueue.push(data);
 	});
-	url = url.replace(/\%27/g, '%2527');
+	url = url.replace(/(\%27|')/g, '%2527');
 	document.write('<iframe src="javascript:location.replace(\''+url+'\');" frameborder="0" id="content" allowtransparency="true" name="content"></iframe>');
 })();
 </script>


### PR DESCRIPTION
### What this Pull Request does?

This Pull Request URL-encodes single quotes with a given URL even if they're already encoded once in an attempt to prevent a [cross-site scripting](https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)) vulnerability.

### Why?

Based on how the player is included on a website, the URL can be crafted to execute external JavaScript on the website. The standard "include the JavaScript snippet" method presented by [scmplayer.co](https://scmplayer.co/) is vulnerable.

This is possible because `location.replace()` in scm.html will evaluate the URL if it contains JavaScript, so consider URLs like the following:

1. `https://www.example.com/?q=%27%2balert(1)%2b%27`
1. `https://www.example.com/'+alert(1)+'`

These, more-easily recognizable in the second example, evaluate to:

    location.replace('https://www.example.com/'+alert(1)+'')

Both will cause the browser to display an alert dialog, or any included JavaScript.

Due to the nested-nature of the evaluation, it also bypasses existing browser controls such as [XSS-Auditor](https://www.chromium.org/developers/design-documents/xss-auditor).

Websites with _strict_ [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) policies should be protected, but the overlap of strict-CSP policies and SCM Music Player may not be much.

### Testing Steps

These are the steps I took to test both the issue and the resolution (e.g. this patch):

1. First, clone the original repo (not with this patch).
1. Create a test.html file and include the following snippet (as given from [scmplayer.co](https://scmplayer.co/)):

        <html>
        <body>
            <script type="text/javascript" src="script.js" data-config="{'skin':'skins/tunes/skin.css','volume':50,'autoplay':false,'shuffle':false,'repeat':1,'placement':'top','showplaylist':false,'playlist':[]}" ></script>
        </body>
        </html>
1. Open the test.html file in your browser.
    - pending whether you're testing this on a domain, or as a local file, the player itself may not load
1. Modify the URL in your browser's address bar to have a crafted query string:

        test.html?%27%2balert(1)%2b%27

    - [ ] Did you see an alert dialog?
1. Now, pull this patch.
1. Refresh the page with the modified URL.
    - [ ] No alert dialog?